### PR TITLE
fix twap oracle and close fee auto convert logic

### DIFF
--- a/src/modules/swap/TokenSwapConfig.move
+++ b/src/modules/swap/TokenSwapConfig.move
@@ -15,6 +15,7 @@ module TokenSwapConfig {
     const DEFAULT_POUNDAGE_NUMERATOR: u64 = 3;
     const DEFAULT_POUNDAGE_DENUMERATOR: u64 = 1000;
 
+    const DEFAULT_SWAP_FEE_AUTO_CONVERT_SWITCH: bool = false;
     const SWAP_FEE_SWITCH_ON: bool = true;
     const SWAP_FEE_SWITCH_OFF: bool = false;
 
@@ -28,6 +29,10 @@ module TokenSwapConfig {
     struct SwapFeeOperationConfig has copy, drop, store {
         numerator: u64,
         denumerator: u64,
+    }
+
+    struct SwapFeeSwitchConfig has copy, drop, store {
+        auto_convert_switch: bool,
     }
 
     public fun get_swap_fee_operation_rate(): (u64, u64) {
@@ -53,6 +58,16 @@ module TokenSwapConfig {
             (numerator, denumerator)
         } else {
             (DEFAULT_POUNDAGE_NUMERATOR, DEFAULT_POUNDAGE_DENUMERATOR)
+        }
+    }
+
+    /// Get fee auto convert switch config
+    public fun get_fee_auto_convert_switch(): (bool) {
+        if (Config::config_exist_by_address<SwapFeeSwitchConfig>(admin_address())) {
+            let conf = Config::get_by_address<SwapFeeSwitchConfig>(admin_address());
+            conf.auto_convert_switch
+        } else {
+            DEFAULT_SWAP_FEE_AUTO_CONVERT_SWITCH
         }
     }
 
@@ -84,6 +99,19 @@ module TokenSwapConfig {
             Config::set<SwapFeePoundageConfig<X, Y>>(signer, config);
         } else {
             Config::publish_new_config<SwapFeePoundageConfig<X, Y>>(signer, config);
+        }
+    }
+
+    /// Set fee auto convert switch config, only admin can call
+    public fun set_fee_auto_convert_switch(signer: &signer, auto_convert_switch: bool) {
+        assert(Signer::address_of(signer) == admin_address(), Errors::invalid_state(ERROR_NOT_HAS_PRIVILEGE));
+        let config = SwapFeeSwitchConfig{
+            auto_convert_switch: auto_convert_switch,
+        };
+        if (Config::config_exist_by_address<SwapFeeSwitchConfig>(admin_address())) {
+            Config::set<SwapFeeSwitchConfig>(signer, config);
+        } else {
+            Config::publish_new_config<SwapFeeSwitchConfig>(signer, config);
         }
     }
 

--- a/src/modules/swap/TokenSwapFee.move
+++ b/src/modules/swap/TokenSwapFee.move
@@ -62,7 +62,7 @@ module TokenSwapFee {
         // Close fee auto converted to usdt logic
         let auto_convert_switch = TokenSwapConfig::get_fee_auto_convert_switch();
         // the token to pay for fee, is fee token
-        if (auto_convert_switch || Token::is_same_token<X, FeeToken>()) {
+        if (!auto_convert_switch || Token::is_same_token<X, FeeToken>()) {
             (fee_handle, swap_fee, fee_out) = swap_fee_direct_deposit<X, Y>(token_x);
         } else {
             // check [X, FeeToken] token pair exist

--- a/src/modules/swap/TokenSwapFee.move
+++ b/src/modules/swap/TokenSwapFee.move
@@ -58,8 +58,11 @@ module TokenSwapFee {
     ) acquires TokenSwapFeeEvent {
         let fee_address = TokenSwapConfig::fee_address();
         let (fee_handle, swap_fee, fee_out);
+
+        // Close fee auto converted to usdt logic
+        let auto_convert_switch = TokenSwapConfig::get_fee_auto_convert_switch();
         // the token to pay for fee, is fee token
-        if (Token::is_same_token<X, FeeToken>()) {
+        if (auto_convert_switch || Token::is_same_token<X, FeeToken>()) {
             (fee_handle, swap_fee, fee_out) = swap_fee_direct_deposit<X, Y>(token_x);
         } else {
             // check [X, FeeToken] token pair exist

--- a/src/modules/swap/TokenSwapRouter.move
+++ b/src/modules/swap/TokenSwapRouter.move
@@ -344,5 +344,11 @@ module TokenSwapRouter {
                                            denum: u64) {
         TokenSwapConfig::set_swap_fee_operation_rate(signer, num, denum);
     }
+
+    /// Set fee auto convert switch config
+    public fun set_fee_auto_convert_switch(signer: &signer, auto_convert_switch: bool) {
+        TokenSwapConfig::set_fee_auto_convert_switch(signer, auto_convert_switch);
+    }
+
 }
 }

--- a/src/modules/swap/TokenSwapScripts.move
+++ b/src/modules/swap/TokenSwapScripts.move
@@ -119,6 +119,11 @@ module TokenSwapScripts {
         TokenSwapRouter::set_swap_fee_operation_rate(&signer, num, denum);
     }
 
+    /// Set fee auto convert switch config
+    public(script) fun set_fee_auto_convert_switch(signer: signer, auto_convert_switch: bool) {
+        TokenSwapRouter::set_fee_auto_convert_switch(&signer, auto_convert_switch);
+    }
+
     /// Get amount in with token pair pondage rate
     public fun get_amount_in<X: copy + drop + store,
                              Y: copy + drop + store>(x_value: u128): u128 {

--- a/tests/testsuite/swap/swap_fee_test.move
+++ b/tests/testsuite/swap/swap_fee_test.move
@@ -167,6 +167,19 @@ script {
 // check: EXECUTED
 
 
+
+//! new-transaction
+//! sender: admin
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapRouter;
+
+    fun open_swap_fee_auto_convert_switch(signer: signer) {
+        TokenSwapRouter::set_fee_auto_convert_switch(&signer, true);
+    }
+}
+// check: EXECUTED
+
+
 //! new-transaction
 //! sender: alice
 address alice = {{alice}};

--- a/tests/testsuite/swap/swap_oracle_test.move
+++ b/tests/testsuite/swap/swap_oracle_test.move
@@ -6,6 +6,52 @@
 //! account: alice, 500000 0x1::STC::STC
 
 
+//! sender: admin
+address admin = {{admin}};
+module admin::SwapOracleWrapper {
+    use 0x1::U256::{Self, U256};
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::FixedPoint128;
+
+    struct SwapOralce<X, Y> has key, store {
+        last_block_timestamp: u64,
+        last_price_x_cumulative: U256,
+        last_price_y_cumulative: U256,
+    }
+
+    /// ignore token pair order, just for test
+    public fun initialize_oralce<X: copy + drop + store, Y: copy + drop + store>(signer: &signer) {
+        let price_oracle = SwapOralce<X, Y>{
+            last_block_timestamp: 0,
+            last_price_x_cumulative: U256::zero(),
+            last_price_y_cumulative: U256::zero(),
+        };
+        move_to(signer, price_oracle);
+    }
+
+    public fun set_last_oracle<X: copy + drop + store, Y: copy + drop + store>(
+        price_x_cumulative: u128,
+        price_y_cumulative: u128,
+        block_timestamp: u64,
+    ) acquires SwapOralce {
+        let price_oracle = borrow_global_mut<SwapOralce<X, Y>>(@admin);
+        price_oracle.last_price_x_cumulative = FixedPoint128::to_u256(FixedPoint128::encode(price_x_cumulative));
+        price_oracle.last_price_y_cumulative = FixedPoint128::to_u256(FixedPoint128::encode(price_y_cumulative));
+        price_oracle.last_block_timestamp = block_timestamp;
+    }
+
+    public fun get_last_oracle<X: copy + drop + store, Y: copy + drop + store>(): (u128, u128, u64) acquires SwapOralce {
+        let price_oracle = borrow_global<SwapOralce<X, Y>>(@admin);
+        let last_block_timestamp = price_oracle.last_block_timestamp;
+        let last_price_x_cumulative_decode = FixedPoint128::decode(FixedPoint128::encode_u256(*&price_oracle.last_price_x_cumulative, false));
+        let last_price_y_cumulative_decode = FixedPoint128::decode(FixedPoint128::encode_u256(*&price_oracle.last_price_y_cumulative, false));
+
+        (last_price_x_cumulative_decode, last_price_y_cumulative_decode, last_block_timestamp)
+    }
+}
+// check: EXECUTED
+
+
+
 //! new-transaction
 //! sender: admin
 script {
@@ -94,10 +140,26 @@ script {
 
 // check: EXECUTED
 
+
+//! new-transaction
+//! sender: admin
+address admin = {{admin}};
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
+    use admin::SwapOracleWrapper;
+
+    fun initialize_oralce(signer: signer) {
+        SwapOracleWrapper::initialize_oralce<WETH, WUSDT>(&signer);
+    }
+}
+
+// check: EXECUTED
+
+
 //! block-prologue
 //! author: genesis
 //! block-number: 1
-//! block-time: 1638415200000
+//! block-time: 1638415260000
 
 //! new-transaction
 //! sender: alice
@@ -126,6 +188,8 @@ script {
         Debug::print(&block_timestamp);
         Debug::print<u128>(&price_x_cumulative);
         Debug::print<u128>(&price_y_cumulative);
+        assert(price_x_cumulative == 0, 1301);
+        assert(price_y_cumulative == 0, 1302);
     }
 }
 // check: EXECUTED
@@ -139,6 +203,7 @@ script {
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
     use 0x1::Debug;
 
+    // block time has not change, does not trigger to update oracle
     fun add_liquidity(signer: signer) {
         // for the first add liquidity
         TokenSwapRouter::add_liquidity<WETH, WUSDT>(&signer, 60000000000000000000000u128, 50000000000000000000000000u128, 100, 100); //e22, e25
@@ -148,6 +213,8 @@ script {
         Debug::print(&block_timestamp);
         Debug::print<u128>(&price_x_cumulative);
         Debug::print<u128>(&price_y_cumulative);
+        assert(price_x_cumulative == 0, 1303);
+        assert(price_y_cumulative == 0, 1304);
     }
 }
 
@@ -156,26 +223,35 @@ script {
 //! block-prologue
 //! author: genesis
 //! block-number: 2
-//! block-time: 1638418200000
+//! block-time: 1638415320000
 
 //! new-transaction
 //! sender: exchanger
+address admin = {{admin}};
 script {
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapRouter;
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapOracleLibrary;
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
     use 0x1::Debug;
+    use 0x1::Timestamp;
+    use admin::SwapOracleWrapper;
 
+    // block time changed, trigger to update oracle
     fun swap_exact_token_for_token(signer: signer) {
         let amount_x_in = 100000000000000000000u128; //e20
         let amount_y_out_min = 25000000000000000u128;
         TokenSwapRouter::swap_exact_token_for_token<WETH, WUSDT>(&signer, amount_x_in, amount_y_out_min);
 
         let (price_x_cumulative, price_y_cumulative, block_timestamp) = TokenSwapOracleLibrary::current_cumulative_prices<WETH, WUSDT>();
+        SwapOracleWrapper::set_last_oracle<WETH, WUSDT>(price_x_cumulative, price_y_cumulative, block_timestamp);
         Debug::print<u128>(&110502);
         Debug::print(&block_timestamp);
         Debug::print<u128>(&price_x_cumulative);
         Debug::print<u128>(&price_y_cumulative);
+        let current_block_timestamp = Timestamp::now_seconds() % (1u64 << 32);
+        Debug::print<u64>(&current_block_timestamp);
+        assert(price_x_cumulative >= 0, 1305);
+        assert(price_y_cumulative >= 0, 1306);
     }
 }
 // check: EXECUTED
@@ -188,6 +264,7 @@ script {
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapOracleLibrary;
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
     use 0x1::Debug;
+    use 0x1::Timestamp;
 
     fun swap_token_for_exact_token(signer: signer) {
         let amount_x_in_max = 500000000000000000000u128;
@@ -199,6 +276,9 @@ script {
         Debug::print(&block_timestamp);
         Debug::print<u128>(&price_x_cumulative);
         Debug::print<u128>(&price_y_cumulative);
+        let current_block_timestamp = Timestamp::now_seconds() % (1u64 << 32);
+        Debug::print<u64>(&current_block_timestamp);
+
     }
 }
 // check: EXECUTED
@@ -207,26 +287,133 @@ script {
 //! block-prologue
 //! author: genesis
 //! block-number: 3
-//! block-time: 1639030000000
+//! block-time: 1638415380000
 
 //! new-transaction
 //! sender: exchanger
+address admin = {{admin}};
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapRouter;
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::FixedPoint128;
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapOracleLibrary;
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
+    use 0x1::Debug;
+    use admin::SwapOracleWrapper;
+
+    /// forward token pair swap
+    fun swap_token_for_exact_token(signer: signer) {
+        let amount_x_in_max = 500000000000000000000u128; //e20
+        let amount_y_out = 2500000000000000000000u128; //e21
+
+        let (price_x_cumulative0, price_y_cumulative0, block_timestamp0) = TokenSwapOracleLibrary::current_cumulative_prices<WETH, WUSDT>();
+        Debug::print<u128>(&110504);
+        Debug::print(&block_timestamp0);
+        Debug::print<u128>(&price_x_cumulative0);
+        Debug::print<u128>(&price_y_cumulative0);
+
+        let (price_x_cumulative_base_a1, price_y_cumulative_base_a1, last_block_timestamp_base_a) = TokenSwapRouter::get_cumulative_info<WETH, WUSDT>();
+        let price_x_cumulative_base_a = FixedPoint128::decode(FixedPoint128::encode_u256(price_x_cumulative_base_a1, false));
+        let price_y_cumulative_base_a = FixedPoint128::decode(FixedPoint128::encode_u256(price_y_cumulative_base_a1, false));
+        Debug::print(&last_block_timestamp_base_a);
+        Debug::print<u128>(&price_x_cumulative_base_a);
+        Debug::print<u128>(&price_y_cumulative_base_a);
+
+        TokenSwapRouter::swap_token_for_exact_token<WETH, WUSDT>(&signer, amount_x_in_max, amount_y_out);
+
+        let (price_x_cumulative, price_y_cumulative, block_timestamp) = TokenSwapOracleLibrary::current_cumulative_prices<WETH, WUSDT>();
+        SwapOracleWrapper::set_last_oracle<WETH, WUSDT>(price_x_cumulative, price_y_cumulative, block_timestamp);
+
+        Debug::print(&block_timestamp);
+        Debug::print<u128>(&price_x_cumulative);
+        Debug::print<u128>(&price_y_cumulative);
+
+        let (price_x_cumulative_base_b1, price_y_cumulative_base_b1, last_block_timestamp_base_b) = TokenSwapRouter::get_cumulative_info<WETH, WUSDT>();
+        let price_x_cumulative_base_b = FixedPoint128::decode(FixedPoint128::encode_u256(price_x_cumulative_base_b1, false));
+        let price_y_cumulative_base_b = FixedPoint128::decode(FixedPoint128::encode_u256(price_y_cumulative_base_b1, false));
+        Debug::print(&last_block_timestamp_base_b);
+        Debug::print<u128>(&price_x_cumulative_base_b);
+        Debug::print<u128>(&price_y_cumulative_base_b);
+
+        assert(price_x_cumulative == price_x_cumulative0, 1307);
+        assert(price_y_cumulative == price_y_cumulative0, 1308);
+        assert(price_x_cumulative_base_b >= price_x_cumulative_base_a, 1309);
+        assert(price_y_cumulative_base_b >= price_y_cumulative_base_a, 1310);
+    }
+}
+// check: EXECUTED
+
+
+//! block-prologue
+//! author: genesis
+//! block-number: 4
+//! block-time: 1638417000000
+
+//! new-transaction
+//! sender: exchanger
+address admin = {{admin}};
 script {
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapRouter;
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapOracleLibrary;
     use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
     use 0x1::Debug;
+    use admin::SwapOracleWrapper;
 
+    /// reverse token pair swap
     fun swap_token_for_exact_token(signer: signer) {
-        let amount_x_in_max = 500000000000000000000u128;
-        let amount_y_out = 2500000000000000000000u128; //e21
-        TokenSwapRouter::swap_token_for_exact_token<WETH, WUSDT>(&signer, amount_x_in_max, amount_y_out);
+        let amount_x_in_max = 6000000000000000000000u128; //e22
+        let amount_y_out = 100000000000000000u128; //e17
 
-        let (price_x_cumulative, price_y_cumulative, block_timestamp) = TokenSwapOracleLibrary::current_cumulative_prices<WETH, WUSDT>();
-        Debug::print<u128>(&110504);
+        let (price_x_cumulative0, price_y_cumulative0, block_timestamp0) = TokenSwapOracleLibrary::current_cumulative_prices<WUSDT, WETH>();
+        Debug::print<u128>(&110505);
+        Debug::print(&block_timestamp0);
+        Debug::print<u128>(&price_x_cumulative0);
+        Debug::print<u128>(&price_y_cumulative0);
+        let (reserve_x0, reserve_y0) = TokenSwapRouter::get_reserves<WUSDT, WETH>();
+        Debug::print<u128>(&reserve_x0);
+        Debug::print<u128>(&reserve_y0);
+
+        TokenSwapRouter::swap_token_for_exact_token<WUSDT, WETH>(&signer, amount_x_in_max, amount_y_out);
+
+        let (price_x_cumulative, price_y_cumulative, block_timestamp) = TokenSwapOracleLibrary::current_cumulative_prices<WUSDT, WETH>();
+        SwapOracleWrapper::set_last_oracle<WETH, WUSDT>(price_x_cumulative, price_y_cumulative, block_timestamp);
         Debug::print(&block_timestamp);
         Debug::print<u128>(&price_x_cumulative);
         Debug::print<u128>(&price_y_cumulative);
+        let (reserve_x, reserve_y) = TokenSwapRouter::get_reserves<WUSDT, WETH>();
+        Debug::print<u128>(&reserve_x);
+        Debug::print<u128>(&reserve_y);
+
+        assert(price_x_cumulative == price_x_cumulative0, 1311);
+        assert(price_y_cumulative == price_y_cumulative0, 1312);
+
+        // assert price cumulative
+        let (last_block_price_x_cumulative, last_block_price_y_cumulative, _) = SwapOracleWrapper::get_last_oracle<WETH, WUSDT>();
+        assert(price_x_cumulative >= last_block_price_x_cumulative, 1311);
+        assert(price_y_cumulative >= last_block_price_y_cumulative, 1312);
+    }
+}
+// check: EXECUTED
+
+
+//! block-prologue
+//! author: genesis
+//! block-number: 5
+//! block-time: 1638418320000
+
+//! new-transaction
+//! sender: exchanger
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapOracleLibrary;
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenMock::{WETH, WUSDT};
+    use 0x1::Debug;
+
+    /// reverse token pair swap
+    fun swap_token_for_exact_token(_: signer) {
+        let (price_x_cumulative0, price_y_cumulative0, block_timestamp0) = TokenSwapOracleLibrary::current_cumulative_prices<WUSDT, WETH>();
+        Debug::print<u128>(&110506);
+        Debug::print(&block_timestamp0);
+        Debug::print<u128>(&price_x_cumulative0);
+        Debug::print<u128>(&price_y_cumulative0);
     }
 }
 // check: EXECUTED

--- a/tests/testsuite/swap/token_swap_config_test.move
+++ b/tests/testsuite/swap/token_swap_config_test.move
@@ -33,3 +33,31 @@ script {
     }
 }
 // check: EXECUTED
+
+
+//! new-transaction
+//! sender: admin
+address admin = {{admin}};
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapConfig;
+
+    fun init_swap_fee_switch_config(_: signer) {
+        let auto_convert_switch = TokenSwapConfig::get_fee_auto_convert_switch();
+        assert(auto_convert_switch == false, 1006);
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+//! sender: admin
+address admin = {{admin}};
+script {
+    use 0x4783d08fb16990bd35d83f3e23bf93b8::TokenSwapConfig;
+
+    fun set_swap_fee_switch_config(signer: signer) {
+        TokenSwapConfig::set_fee_auto_convert_switch(&signer, true);
+        let auto_convert_switch = TokenSwapConfig::get_fee_auto_convert_switch();
+        assert(auto_convert_switch == true, 1007);
+    }
+}
+// check: EXECUTED


### PR DESCRIPTION
1，Fix twap oracle calculations are inaccurate in some conditions；
2，Close fee auto converted to usdt logic befor bridge ready.