### PR TITLE
Tokenomic ido

### DIFF
--- a/src/modules/gov/TokenSwapGovPoolType.move
+++ b/src/modules/gov/TokenSwapGovPoolType.move
@@ -14,12 +14,5 @@ module TokenSwapGovPoolType {
     struct PoolTypeDeveloperFund has key, store {}
 
     struct PoolTypeProtocolTreasury has key, store {}
-
-    // Deprecated TODO to be removed
-    struct PoolTypeInitialLiquidity has key, store {}
-    // Deprecated TODO to be removed
-    struct PoolTypeTeam has key, store {}
-    // Deprecated TODO to be removed
-    struct PoolTypeDaoTreasury has key, store {}
 }
 }

--- a/src/modules/gov/TokenSwapGovPoolType.move
+++ b/src/modules/gov/TokenSwapGovPoolType.move
@@ -1,19 +1,25 @@
 // Copyright (c) The Elements Studio Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO: replace the address with admin address
 address 0x8c109349c6bd91411d6bc962e080c4a3 {
 module TokenSwapGovPoolType {
-    struct PoolTypeInitialLiquidity has key, store {}
-
     struct PoolTypeFarmPool has key, store {}
 
     struct PoolTypeSyrup has key, store {}
 
-    struct PoolTypeTeam has key, store {}
-
     struct PoolTypeCommunity has key, store {}
 
+    struct PoolTypeIDO has key, store {}
+
+    struct PoolTypeDeveloperFund has key, store {}
+
+    struct PoolTypeProtocolTreasury has key, store {}
+
+    // Deprecated TODO to be removed
+    struct PoolTypeInitialLiquidity has key, store {}
+    // Deprecated TODO to be removed
+    struct PoolTypeTeam has key, store {}
+    // Deprecated TODO to be removed
     struct PoolTypeDaoTreasury has key, store {}
 }
 }

--- a/tests/testsuite/gov/token_swap_gov_test.move
+++ b/tests/testsuite/gov/token_swap_gov_test.move
@@ -60,12 +60,12 @@ script {
     use 0x8c109349c6bd91411d6bc962e080c4a3::STAR;
     use 0x8c109349c6bd91411d6bc962e080c4a3::TokenSwapGov;
     use 0x8c109349c6bd91411d6bc962e080c4a3::TokenSwapGovPoolType::{
-        PoolTypeInitialLiquidity,
+        PoolTypeIDO,
         PoolTypeCommunity,
     };
 
     fun main(signer: signer) {
-        TokenSwapGov::dispatch<PoolTypeInitialLiquidity>(&signer, @alice, 10000000);
+        TokenSwapGov::dispatch<PoolTypeIDO>(&signer, @alice, 10000000);
         TokenSwapGov::dispatch<PoolTypeCommunity>(&signer, @alice, 20000000);
 
         let balance = Account::balance<STAR::STAR>(@alice);


### PR DESCRIPTION
这个pr里其实包两部分内容，
1）显示兼容性升级，调整了经济模型不同项的比例，以及PoolType类型，第一次更新主网；
2）调整后，再清理掉老的类型和upgrade方法，第二次更新主网。
所以最终的diff里不再包含老的类型和方法，算是达到了一种比较干净的升级效果。