### PR TITLE
Aptos usdt dependency

### DIFF
--- a/aptos/bridge-mock/.gitignore
+++ b/aptos/bridge-mock/.gitignore
@@ -1,0 +1,3 @@
+release/
+build/
+.idea/

--- a/aptos/bridge-mock/Move.toml
+++ b/aptos/bridge-mock/Move.toml
@@ -1,11 +1,10 @@
 [package]
-name = "StarswapAptosCore"
+name = "bridge-mock"
 version = "1.0.0"
-#upgrade_policy = "immutable"
 
 [addresses]
-SwapAdmin = "0xf23ffd29758ed5c3dbd44ac8564d9a3976357f6bd330025f7cc3a211b1c48dff"
-SwapFeeAdmin = "0xf23ffd29758ed5c3dbd44ac8564d9a3976357f6bd330025f7cc3a211b1c48dff"
+#bridge = "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa"
+bridge = "0x9bf32e42c442ae2adbc87bc7923610621469bf183266364503a7a434fe9d50ca"
 move_std = "0x1"
 aptos_framework = "0x1"
 aptos_std = "0x1"
@@ -15,6 +14,3 @@ aptos_token = "0x3"
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-framework"}
 #AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-stdlib"}
 #MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/move-stdlib"}
-#bridge = { local = "../bridge" }
-bridge-mock = { local = "../bridge-mock" }
-#bridge = { git = "https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract.git", rev = "95dafa66708904b96272eeca59834aefc55a7182", subdir = "apps/bridge"}

--- a/aptos/bridge-mock/sources/asset.move
+++ b/aptos/bridge-mock/sources/asset.move
@@ -1,0 +1,33 @@
+
+module bridge::asset {
+    use aptos_framework::coin::{Self};
+    use aptos_framework::managed_coin;
+    use std::signer;
+
+    /// USDT token marker.
+    struct USDT has copy, drop, store {}
+
+    /// precision of USDT token.
+    const PRECISION: u8 = 6;
+
+    /// USDT initialization.
+    public entry fun init(account: &signer) {
+//        Token::register_token<USDT>(account, PRECISION);
+//        Account::do_accept_token<USDT>(account);
+
+        managed_coin::initialize<USDT>(
+            account,
+            b"USDT Coin",
+            b"USDT",
+            PRECISION,
+            true,
+        );
+        coin::register<USDT>(account);
+    }
+
+    public entry fun mint(account: &signer, amount: u128) {
+        let dst_addr = signer::address_of(account);
+        managed_coin::mint<USDT>(account, dst_addr, (amount as u64))
+    }
+
+}

--- a/aptos/bridge/Move.toml
+++ b/aptos/bridge/Move.toml
@@ -3,13 +3,7 @@ name = "bridge"
 version = "1.0.0"
 
 [addresses]
-bridge = "0x9bf32e42c442ae2adbc87bc7923610621469bf183266364503a7a434fe9d50ca"
-move_std = "0x1"
-aptos_framework = "0x1"
-aptos_std = "0x1"
-aptos_token = "0x3"
+bridge = "0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa"
+#bridge = "0x9bf32e42c442ae2adbc87bc7923610621469bf183266364503a7a434fe9d50ca"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-framework"}
-AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-stdlib"}
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/move-stdlib"}

--- a/aptos/bridge/sources/asset.move
+++ b/aptos/bridge/sources/asset.move
@@ -1,33 +1,9 @@
-
 module bridge::asset {
-    use aptos_framework::coin::{Self};
-    use aptos_framework::managed_coin;
-    use std::signer;
+    struct USDC {}
+    struct USDT {}
+    struct BUSD {}
+    struct USDD {}
 
-    /// USDT token marker.
-    struct USDT has copy, drop, store {}
-
-    /// precision of USDT token.
-    const PRECISION: u8 = 6;
-
-    /// USDT initialization.
-    public entry fun init(account: &signer) {
-//        Token::register_token<USDT>(account, PRECISION);
-//        Account::do_accept_token<USDT>(account);
-
-        managed_coin::initialize<USDT>(
-            account,
-            b"USDT Coin",
-            b"USDT",
-            PRECISION,
-            true,
-        );
-        coin::register<USDT>(account);
-    }
-
-    public entry fun mint(account: &signer, amount: u128) {
-        let dst_addr = signer::address_of(account);
-        managed_coin::mint<USDT>(account, dst_addr, (amount as u64))
-    }
-
+    struct WETH {}
+    struct WBTC {}
 }

--- a/aptos/farming/Move.toml
+++ b/aptos/farming/Move.toml
@@ -12,6 +12,6 @@ aptos_token = "0x3"
 
 [dependencies]
 AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-framework"}
-AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-stdlib"}
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/move-stdlib"}
+#AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/aptos-stdlib"}
+#MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", rev = "01108a2345b87d539d54a67b32db55193f9ace40", subdir = "aptos-move/framework/move-stdlib"}
 StarswapAptosCore = {local = "../core"}

--- a/aptos/scripts/devnet_deploy.sh
+++ b/aptos/scripts/devnet_deploy.sh
@@ -14,10 +14,10 @@
 #cd aptos目录，为了方便，依赖的项目临时使用swap同样的地址来测试
 
 ### 编译依赖项目usdt-dep
-aptos move compile  --package-dir ./bridge  --named-addresses bridge=devnet-admin
+aptos move compile  --package-dir ./bridge-mock  --named-addresses bridge=devnet-admin
 
 ### 部署依赖项目usdt-dep
-aptos move publish  --package-dir ./bridge  --named-addresses bridge=devnet-admin --profile devnet-admin  --included-artifacts sparse --assume-yes
+aptos move publish  --package-dir ./bridge-mock  --named-addresses bridge=devnet-admin --profile devnet-admin  --included-artifacts sparse --assume-yes
 sleep 5
 
 ### 编译依赖项目u256

--- a/aptos/scripts/mainnet_pre_deploy.sh
+++ b/aptos/scripts/mainnet_pre_deploy.sh
@@ -14,11 +14,11 @@
 #cd aptos目录，为了方便，依赖的项目临时使用swap同样的地址来测试
 
 ### 编译依赖项目usdt-dep
-aptos move compile  --package-dir ./bridge  --named-addresses bridge=mainnet-admin
+#aptos move compile  --package-dir ./bridge  --named-addresses bridge=mainnet-admin
 
 ### 部署依赖项目usdt-dep
-aptos move publish  --package-dir ./bridge  --named-addresses bridge=mainnet-admin --profile mainnet-admin  --included-artifacts sparse --assume-yes
-sleep 5
+#aptos move publish  --package-dir ./bridge  --named-addresses bridge=mainnet-admin --profile mainnet-admin  --included-artifacts sparse --assume-yes
+#sleep 5
 
 ### 编译依赖项目u256
 #aptos move compile  --package-dir ./u256-dep  --named-addresses u256=mainnet-admin

--- a/aptos/scripts/testnet_deploy.sh
+++ b/aptos/scripts/testnet_deploy.sh
@@ -14,10 +14,10 @@
 #cd aptos目录，为了方便，依赖的项目临时使用swap同样的地址来测试
 
 ### 编译依赖项目usdt-dep
-aptos move compile  --package-dir ./bridge  --named-addresses bridge=testnet-admin
+aptos move compile  --package-dir ./bridge-mock  --named-addresses bridge=testnet-admin
 
 ### 部署依赖项目usdt-dep
-aptos move publish  --package-dir ./bridge  --named-addresses bridge=testnet-admin --profile testnet-admin  --included-artifacts sparse --assume-yes
+aptos move publish  --package-dir ./bridge-mock  --named-addresses bridge=testnet-admin --profile testnet-admin  --included-artifacts sparse --assume-yes
 sleep 5
 
 ### 编译依赖项目u256


### PR DESCRIPTION
背景：
Starswap Aptos主网上线版本，USDT使用的是Layerzero bridge的USDT（LayerZero USDT 0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDT），其git仓库：https://github.com/LayerZero-Labs/LayerZero-Aptos-Contract.git。
Layerzero是一个庞大的仓库，工程采用了git module来管理，Starswap只是单纯依赖了USDT，如果直接依赖Layerzero工程， 会让整个依赖变的复杂，git module编译需要执行：git submodule update --init --recursive。

解决方案：
依赖git submodule虽然可行，但是太复杂。
简化方案为，直接将依赖的asset文件抽出来，基于local依赖和编译。
不过还有个问题，基于0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa的USDT只在aptos主网有部署，testnet和devnet都未部署，为了测试，用starswap admin地址mock了USDT，方便testnet和devnet测试。
