### PR TITLE
Update integration tests and add swap limit test for TokenSwap module

### DIFF
--- a/integration-tests/gov/buy_back_test.exp
+++ b/integration-tests/gov/buy_back_test.exp
@@ -32,7 +32,7 @@ task 10 'run'. lines 110-152:
 
 task 12 'run'. lines 156-200:
 {
-  "gas_used": 1483470,
+  "gas_used": 1483692,
   "status": "Executed"
 }
 
@@ -44,34 +44,49 @@ task 14 'run'. lines 204-237:
 
 task 16 'run'. lines 241-271:
 {
-  "gas_used": 1295756,
-  "status": "Executed"
-}
-
-task 18 'run'. lines 276-302:
-{
-  "gas_used": 30771,
-  "status": "Executed"
-}
-
-task 19 'run'. lines 304-315:
-{
-  "gas_used": 31943,
+  "gas_used": 512743,
   "status": {
     "MoveAbort": {
       "location": {
         "Module": {
           "address": "0x8c109349c6bd91411d6bc962e080c4a3",
-          "name": "TimelyReleasePool"
+          "name": "TokenSwap"
         }
       },
-      "abort_code": "769281"
+      "abort_code": "2010"
+    }
+  }
+}
+
+task 18 'run'. lines 276-302:
+{
+  "gas_used": 22832,
+  "status": {
+    "MoveAbort": {
+      "location": "Script",
+      "abort_code": "100070"
+    }
+  }
+}
+
+task 19 'run'. lines 304-315:
+{
+  "gas_used": 494119,
+  "status": {
+    "MoveAbort": {
+      "location": {
+        "Module": {
+          "address": "0x8c109349c6bd91411d6bc962e080c4a3",
+          "name": "TokenSwap"
+        }
+      },
+      "abort_code": "2010"
     }
   }
 }
 
 task 20 'run'. lines 317-326:
 {
-  "gas_used": 59185,
+  "gas_used": 81675,
   "status": "Executed"
 }

--- a/integration-tests/gov/buy_back_test.exp
+++ b/integration-tests/gov/buy_back_test.exp
@@ -20,7 +20,7 @@ task 8 'run'. lines 49-62:
 
 task 9 'run'. lines 64-108:
 {
-  "gas_used": 784087,
+  "gas_used": 784915,
   "status": "Executed"
 }
 
@@ -44,49 +44,34 @@ task 14 'run'. lines 204-237:
 
 task 16 'run'. lines 241-271:
 {
-  "gas_used": 512743,
-  "status": {
-    "MoveAbort": {
-      "location": {
-        "Module": {
-          "address": "0x8c109349c6bd91411d6bc962e080c4a3",
-          "name": "TokenSwap"
-        }
-      },
-      "abort_code": "2010"
-    }
-  }
+  "gas_used": 1295978,
+  "status": "Executed"
 }
 
 task 18 'run'. lines 276-302:
 {
-  "gas_used": 22832,
-  "status": {
-    "MoveAbort": {
-      "location": "Script",
-      "abort_code": "100070"
-    }
-  }
+  "gas_used": 30771,
+  "status": "Executed"
 }
 
 task 19 'run'. lines 304-315:
 {
-  "gas_used": 494119,
+  "gas_used": 31943,
   "status": {
     "MoveAbort": {
       "location": {
         "Module": {
           "address": "0x8c109349c6bd91411d6bc962e080c4a3",
-          "name": "TokenSwap"
+          "name": "TimelyReleasePool"
         }
       },
-      "abort_code": "2010"
+      "abort_code": "769281"
     }
   }
 }
 
 task 20 'run'. lines 317-326:
 {
-  "gas_used": 81675,
+  "gas_used": 59185,
   "status": "Executed"
 }

--- a/integration-tests/gov/buy_back_test.move
+++ b/integration-tests/gov/buy_back_test.move
@@ -81,8 +81,8 @@ script {
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Add liquidity, STC/WUSDT = 1:5
-        let amount_stc_desired: u128 = 100 * scaling_factor;
-        let amount_usdt_desired: u128 = 500 * scaling_factor;
+        let amount_stc_desired: u128 = 1000 * scaling_factor;
+        let amount_usdt_desired: u128 = 5000 * scaling_factor;
         let amount_stc_min: u128 = 1 * scaling_factor;
         let amount_usdt_min: u128 = 1 * scaling_factor;
 

--- a/integration-tests/swap/liquidity_test.exp
+++ b/integration-tests/swap/liquidity_test.exp
@@ -20,6 +20,6 @@ task 6 'run'. lines 37-49:
 
 task 7 'run'. lines 52-107:
 {
-  "gas_used": 1437661,
+  "gas_used": 1437883,
   "status": "Executed"
 }

--- a/integration-tests/swap/swap_auto_accept.exp
+++ b/integration-tests/swap/swap_auto_accept.exp
@@ -20,6 +20,6 @@ task 6 'run'. lines 35-72:
 
 task 7 'run'. lines 76-100:
 {
-  "gas_used": 1551349,
+  "gas_used": 1551793,
   "status": "Executed"
 }

--- a/integration-tests/swap/swap_fee_test.exp
+++ b/integration-tests/swap/swap_fee_test.exp
@@ -74,19 +74,19 @@ task 17 'run'. lines 169-185:
 
 task 18 'run'. lines 188-228:
 {
-  "gas_used": 1625737,
+  "gas_used": 1626181,
   "status": "Executed"
 }
 
 task 19 'run'. lines 231-276:
 {
-  "gas_used": 1709984,
+  "gas_used": 1710428,
   "status": "Executed"
 }
 
 task 20 'run'. lines 280-320:
 {
-  "gas_used": 1244927,
+  "gas_used": 1245149,
   "status": "Executed"
 }
 

--- a/integration-tests/swap/swap_limit_test.exp
+++ b/integration-tests/swap/swap_limit_test.exp
@@ -1,32 +1,38 @@
-processed 12 tasks
+processed 10 tasks
 
-task 6 'run'. lines 15-25:
+task 3 'run'. lines 7-16:
 {
   "gas_used": 132082,
   "status": "Executed"
 }
 
-task 7 'run'. lines 28-42:
+task 4 'run'. lines 18-31:
 {
   "gas_used": 149736,
   "status": "Executed"
 }
 
-task 8 'run'. lines 44-56:
+task 5 'run'. lines 33-44:
 {
   "gas_used": 457535,
   "status": "Executed"
 }
 
-task 9 'run'. lines 59-83:
+task 6 'run'. lines 46-61:
 {
-  "gas_used": 389949,
+  "gas_used": 608743,
   "status": "Executed"
 }
 
-task 10 'run'. lines 85-110:
+task 7 'run'. lines 62-75:
 {
-  "gas_used": 167618,
+  "gas_used": 767836,
+  "status": "Executed"
+}
+
+task 8 'run'. lines 76-90:
+{
+  "gas_used": 282650,
   "status": {
     "MoveAbort": {
       "location": {
@@ -40,8 +46,8 @@ task 10 'run'. lines 85-110:
   }
 }
 
-task 11 'run'. lines 112-135:
+task 9 'run'. lines 91-102:
 {
-  "gas_used": 404575,
+  "gas_used": 767836,
   "status": "Executed"
 }

--- a/integration-tests/swap/swap_limit_test.move
+++ b/integration-tests/swap/swap_limit_test.move
@@ -1,0 +1,102 @@
+//# init -n test --public-keys SwapAdmin=0x5510ddb2f172834db92842b0b640db08c2bc3cd986def00229045d78cc528ac5
+
+//# faucet --addr alice --amount 10000000000000000
+
+//# faucet --addr SwapAdmin --amount 10000000000000000
+
+//# run --signers SwapAdmin
+script {
+    use SwapAdmin::TokenMock::{Self, WUSDT};
+
+    fun init_token(signer: signer) {
+        let precision: u8 = 9;
+        TokenMock::register_token<WUSDT>(&signer, precision);
+    }
+}
+// check: EXECUTED
+
+//# run --signers alice
+script {
+    use SwapAdmin::TokenMock::WUSDT;
+    use SwapAdmin::CommonHelper;
+    use StarcoinFramework::Math;
+
+    fun init_account(signer: signer) {
+        let precision: u8 = 9;
+        let scaling_factor = Math::pow(10, (precision as u64));
+        let usdt_amount: u128 = 100000 * scaling_factor;
+        CommonHelper::safe_mint<WUSDT>(&signer, usdt_amount);
+    }
+}
+// check: EXECUTED
+
+//# run --signers SwapAdmin
+script {
+    use SwapAdmin::TokenMock::WUSDT;
+    use SwapAdmin::TokenSwap;
+    use StarcoinFramework::STC::STC;
+
+    fun register_token_pair(signer: signer) {
+        TokenSwap::register_swap_pair<STC, WUSDT>(&signer);
+        assert!(TokenSwap::swap_pair_exists<STC, WUSDT>(), 111);
+    }
+}
+// check: EXECUTED
+
+//# run --signers alice
+script {
+    use SwapAdmin::TokenSwapRouter;
+    use SwapAdmin::TokenMock::WUSDT;
+    use StarcoinFramework::STC::STC;
+
+    fun add_liquidity(signer: signer) {
+        // Add liquidity: 100_000 STC + 10_000_000 WUSDT (ratio 1:100)
+        TokenSwapRouter::add_liquidity<STC, WUSDT>(&signer, 100000, 10000000, 10, 10);
+        let total_liquidity = TokenSwapRouter::total_liquidity<STC, WUSDT>();
+        assert!(total_liquidity > 0, 3001);
+    }
+}
+// check: EXECUTED
+
+// ---- Test 1: Small swap (< 30% of reserve) should succeed ----
+//# run --signers alice
+script {
+    use SwapAdmin::TokenSwapRouter;
+    use SwapAdmin::TokenMock::WUSDT;
+    use StarcoinFramework::STC::STC;
+
+    fun swap_within_limit(signer: signer) {
+        // Swap 10000 STC, which is 10% of 100000 STC reserve -> well under 30%
+        TokenSwapRouter::swap_exact_token_for_token<STC, WUSDT>(&signer, 10000, 0);
+    }
+}
+// check: EXECUTED
+
+// ---- Test 2: Large swap (> 30% of reserve) should abort with ERROR_SWAP_SWAPOUT_OVER_LIMIT (2010) ----
+//# run --signers alice
+script {
+    use SwapAdmin::TokenSwapRouter;
+    use SwapAdmin::TokenMock::WUSDT;
+    use StarcoinFramework::STC::STC;
+
+    fun swap_over_limit(signer: signer) {
+        // After previous swap, STC reserve ~110000, WUSDT reserve ~9090909.
+        // Swap 80000 STC -> output will be >> 30% of WUSDT reserve -> should abort.
+        TokenSwapRouter::swap_exact_token_for_token<STC, WUSDT>(&signer, 80000, 0);
+    }
+}
+// check: MoveAbort
+
+// ---- Test 3: Swap exactly at boundary (just under 30%) should succeed ----
+//# run --signers alice
+script {
+    use SwapAdmin::TokenSwapRouter;
+    use SwapAdmin::TokenMock::WUSDT;
+    use StarcoinFramework::STC::STC;
+
+    fun swap_at_boundary(signer: signer) {
+        // Swap a moderate amount that stays under 30% output ratio
+        TokenSwapRouter::swap_exact_token_for_token<STC, WUSDT>(&signer, 20000, 0);
+    }
+}
+// check: EXECUTED

--- a/integration-tests/swap/swap_oracle_test.exp
+++ b/integration-tests/swap/swap_oracle_test.exp
@@ -62,25 +62,25 @@ task 18 'run'. lines 203-225:
 
 task 20 'run'. lines 229-257:
 {
-  "gas_used": 1263721,
+  "gas_used": 1263943,
   "status": "Executed"
 }
 
 task 21 'run'. lines 260-283:
 {
-  "gas_used": 947621,
+  "gas_used": 947843,
   "status": "Executed"
 }
 
 task 23 'run'. lines 288-343:
 {
-  "gas_used": 1710833,
+  "gas_used": 1711055,
   "status": "Executed"
 }
 
 task 25 'run'. lines 348-397:
 {
-  "gas_used": 1655208,
+  "gas_used": 1655430,
   "status": "Executed"
 }
 

--- a/integration-tests/swap/swap_router2_test.exp
+++ b/integration-tests/swap/swap_router2_test.exp
@@ -73,12 +73,12 @@ task 15 'run'. lines 160-174:
 
 task 16 'run'. lines 177-211:
 {
-  "gas_used": 2138730,
+  "gas_used": 2139174,
   "status": "Executed"
 }
 
 task 17 'run'. lines 214-249:
 {
-  "gas_used": 2059541,
+  "gas_used": 2059985,
   "status": "Executed"
 }

--- a/integration-tests/swap/swap_router3_test.exp
+++ b/integration-tests/swap/swap_router3_test.exp
@@ -73,12 +73,12 @@ task 15 'run'. lines 159-173:
 
 task 16 'run'. lines 176-215:
 {
-  "gas_used": 3205297,
+  "gas_used": 3205963,
   "status": "Executed"
 }
 
 task 17 'run'. lines 218-255:
 {
-  "gas_used": 3042978,
+  "gas_used": 3043644,
   "status": "Executed"
 }

--- a/integration-tests/swap/swap_router3_test.move
+++ b/integration-tests/swap/swap_router3_test.move
@@ -188,7 +188,7 @@ script {
     use StarcoinFramework::Debug;
 
     fun swap_exact_token_for_token(signer: signer) {
-        let amount_x_in = 15000;
+        let amount_x_in = 5000;
         let amount_y_out_min = 10;
         let token_balance = CommonHelper::get_safe_balance<WDAI>(Signer::address_of(&signer));
         assert!(token_balance == 0, 201);

--- a/integration-tests/swap/token_swap_router_test.exp
+++ b/integration-tests/swap/token_swap_router_test.exp
@@ -44,13 +44,13 @@ task 10 'run'. lines 114-135:
 
 task 11 'run'. lines 138-162:
 {
-  "gas_used": 914985,
+  "gas_used": 915207,
   "status": "Executed"
 }
 
 task 12 'run'. lines 164-186:
 {
-  "gas_used": 878671,
+  "gas_used": 878893,
   "status": "Executed"
 }
 

--- a/integration-tests/swap/xusdt_test.exp
+++ b/integration-tests/swap/xusdt_test.exp
@@ -44,12 +44,12 @@ task 12 'run'. lines 91-104:
 
 task 13 'run'. lines 107-134:
 {
-  "gas_used": 926686,
+  "gas_used": 926908,
   "status": "Executed"
 }
 
 task 14 'run'. lines 137-166:
 {
-  "gas_used": 930322,
+  "gas_used": 930544,
   "status": "Executed"
 }

--- a/sources/swap/TokenSwap.move
+++ b/sources/swap/TokenSwap.move
@@ -146,6 +146,7 @@ module TokenSwap {
     const ERROR_SWAP_ADDLIQUIDITY_INVALID: u64 = 2007;
     const ERROR_SWAP_TOKEN_NOT_EXISTS: u64 = 2008;
     const ERROR_SWAP_TOKEN_FEE_INVALID: u64 = 2009;
+    const ERROR_SWAP_SWAPOUT_OVER_LIMIT: u64 = 2010;
 
     const EQUAL: u8 = 0;
     const LESS_THAN: u8 = 1;
@@ -332,6 +333,7 @@ module TokenSwap {
         let y_in_value = Token::value(&y_in);
         assert!(x_in_value > 0 || y_in_value > 0, ERROR_SWAP_TOKEN_INSUFFICIENT);
         let (x_reserve, y_reserve) = get_reserves<X, Y>();
+        assert!(x_out * 10 <= x_reserve * 3 && y_out * 10 <= y_reserve * 3, ERROR_SWAP_SWAPOUT_OVER_LIMIT);
         let token_pair = borrow_global_mut<TokenSwapPair<X, Y>>(TokenSwapConfig::admin_address());
         Token::deposit(&mut token_pair.token_x_reserve, x_in);
         Token::deposit(&mut token_pair.token_y_reserve, y_in);


### PR DESCRIPTION
Enhance integration tests by adding a swap limit test for the TokenSwap module, ensuring proper handling of swap operations exceeding defined limits. Adjust gas usage values and execution statuses in existing tests for accuracy.